### PR TITLE
CSMS-1215/unauthorized/response

### DIFF
--- a/houndify_client.go
+++ b/houndify_client.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"github.com/pkg/errors"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -12,6 +11,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 const houndifyVoiceURL = "https://api.houndify.com:443/v1/audio"
@@ -255,7 +256,12 @@ func (c *Client) VoiceSearch(voiceReq VoiceRequest, partialTranscriptChan chan P
 	defer resp.Body.Close()
 
 	//don't try to parse out conversation state from a bad response
+	fmt.Println("Billy Test... resp.StatusCode: ", resp.StatusCode)
 	if resp.StatusCode >= 400 {
+		fmt.Println("resp.statusCode: ", resp.StatusCode)
+		if resp.StatusCode == 401 {
+			return bodyStr, errors.New("unauthorized")
+		}
 		return bodyStr, errors.New("error response")
 	}
 	// update with new conversation state

--- a/houndify_client.go
+++ b/houndify_client.go
@@ -256,13 +256,14 @@ func (c *Client) VoiceSearch(voiceReq VoiceRequest, partialTranscriptChan chan P
 	defer resp.Body.Close()
 
 	//don't try to parse out conversation state from a bad response
-	fmt.Println("Billy Test... resp.StatusCode: ", resp.StatusCode)
 	if resp.StatusCode >= 400 {
-		fmt.Println("resp.statusCode: ", resp.StatusCode)
-		if resp.StatusCode == 401 {
+		switch resp.StatusCode {
+		case http.StatusUnauthorized:
+		case http.StatusForbidden:
 			return bodyStr, errors.New("unauthorized")
+		default:
+			return bodyStr, errors.New("error response")
 		}
-		return bodyStr, errors.New("error response")
 	}
 	// update with new conversation state
 	if c.enableConversationState {


### PR DESCRIPTION
## Description
Return `"unauthorized"` error upon `401`/`403` HTTP status codes. 

[Testing](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Fdev$252Faudio-hive$252Fecs-logs/log-events/$252Fdev$252Faudio-hive$252Faudio-hive-container$252F0f23106cb9e94c8a8e7ec22aa88a7e07) shows that the API returns `403` when we provide invalid credentials. I chose to consolidate into a single error so it'd be a simpler check, and to use the word "unauthorized" as it felt more appropriate for the generic case (also surprised the API didn't return `401` with the invalid key. I tried both invalid id/key and every combo produced `403`. 

[Test with both invalid id/key](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Fdev$252Faudio-hive$252Fecs-logs/log-events/$252Fdev$252Faudio-hive$252Faudio-hive-container$252F17cf36becd254d92803ae29a81a15a52)

[commit](https://github.com/soundhound/houndify-sdk-go/commit/1dc2681ea9bad34864ce9b62bb012de06caaf829)
<img width="637" alt="image" src="https://user-images.githubusercontent.com/88403804/222859942-b7efb329-6251-4c82-9720-958e83a4d256.png">

Test with bad key
<img width="1892" alt="image" src="https://user-images.githubusercontent.com/88403804/222859819-39f63dec-9e48-449d-b3c6-9c3631bc0b89.png">